### PR TITLE
Init default Mac toolbar menu

### DIFF
--- a/scout-files/_scripts/app.js
+++ b/scout-files/_scripts/app.js
@@ -10,6 +10,11 @@
     var sass = require('node-sass');
     var chokidar = require('chokidar');
     var path = require('path');
+    var gui = require('nw.gui');
+    var mb = new gui.Menu({type:"menubar"});
+
+    mb.createMacBuiltin("Scout-App");
+    gui.Window.get().menu = mb;
 
     // Get versions
     scout.versions.nodeSass = sass.info.split('\n')[0].replace('node-sass', '').replace('(Wrapper)', '').replace('[JavaScript]', '').trim();


### PR DESCRIPTION
This change activates the default Mac toolbar and also allows default keyboard shortcuts such as CMD + Z for undo, CMD + M to minimize and most important thing CMD + H to hide window .

Screenshot: ![asd](http://i.pics.rs/iRDUe.jpg) 
(real app name should be displayed when app is packaged)

Source: https://github.com/nwjs/nw.js/wiki/window-menu